### PR TITLE
fix: suppress help text for runtime errors, only show for usage errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -185,7 +185,25 @@ func run(cmd *cobra.Command, args []string) error {
 			// This is handled inside workflow, but just in case
 			return nil
 		}
-		return err
+
+		// Check error type to determine if help should be shown
+		errType := errors.GetType(err)
+		switch errType {
+		case errors.ErrTypeGit, errors.ErrTypeNetwork, errors.ErrTypeAuth,
+			errors.ErrTypeTimeout, errors.ErrTypeLLM, errors.ErrTypeProvider,
+			errors.ErrTypePR, errors.ErrTypeExternal:
+			// Runtime/execution errors - don't show help, just show error message
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			errors.HandleFatal(err)
+		case errors.ErrTypeConfig, errors.ErrTypeValidation:
+			// Configuration/validation errors - show help as it may be useful
+			return err
+		default:
+			// Unknown errors - default to not showing help to avoid noise
+			cmd.SilenceUsage = true
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes issue #17 where help text was inappropriately displayed for runtime errors.

## Summary
- Only display help message when user input/parameters are invalid
- Suppress help for runtime errors (Git, network, LLM, etc.) to show only relevant error message
- Maintains help display for validation/configuration errors where help is useful

## Changes
- Modified error handling logic in cmd/root.go run function
- Added error type checking to differentiate between usage and runtime errors
- Maintains backward compatibility for existing error handling

Generated with [Claude Code](https://claude.ai/code)