### PR TITLE
docs: add squash rebase usage examples to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ catmit squash --lang zh
 # Custom timeout
 catmit squash --timeout 60
 
+# Squash unpushed commits using interactive rebase
+catmit squash --rebase
+catmit squash -r  # shorthand
+# Combine with other options
+catmit squash --rebase --no-confirm --lang zh
+
 # Example workflow:
 $ catmit squash
 # Opens your default editor to input commit messages
@@ -263,6 +269,14 @@ feat: implement complete authentication system
 - Update authentication documentation
 
 ✓ Copied to clipboard
+
+# Example rebase workflow:
+$ catmit squash --rebase
+# Analyzes unpushed commits
+# Generates consolidated commit message using AI
+# Performs interactive rebase with backup branch creation
+# ✓ Rebase completed successfully
+# Backup branch: backup-feature-branch-20250122-123456
 ```
 
 ### 🚀 Pull Request Creation

--- a/README_zh.md
+++ b/README_zh.md
@@ -250,6 +250,12 @@ catmit squash --lang zh
 # 自定义超时时间
 catmit squash --timeout 60
 
+# 使用交互式变基合并未推送的提交
+catmit squash --rebase
+catmit squash -r  # 简写
+# 与其他选项组合使用
+catmit squash --rebase --no-confirm --lang zh
+
 # 示例工作流：
 $ catmit squash
 # 打开默认编辑器输入提交信息
@@ -263,6 +269,14 @@ feat: 实现完整的认证系统
 - 更新认证相关文档
 
 ✓ 已复制到剪贴板
+
+# 变基工作流示例：
+$ catmit squash --rebase
+# 分析未推送的提交
+# 使用 AI 生成合并的提交信息
+# 执行交互式变基并创建备份分支
+# ✓ 变基成功完成
+# 备份分支: backup-feature-branch-20250122-123456
 ```
 
 ### 🚀 Pull Request 创建


### PR DESCRIPTION
Add comprehensive documentation for the `--rebase` functionality in the squash command.

## Changes
- Add `--rebase` flag documentation with shorthand `-r`
- Include rebase workflow examples for interactive mode
- Update both English and Chinese README versions
- Document backup branch creation during rebase operations
- Show combined usage with other flags like `--no-confirm` and `--lang`

Closes #21

Generated with [Claude Code](https://claude.ai/code)